### PR TITLE
Add LeagueNews module to fetch and save League of Legends news

### DIFF
--- a/PythonProject3/LeagueNews.py
+++ b/PythonProject3/LeagueNews.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+from bs4 import BeautifulSoup
+from datetime import datetime
+from srcs import game_news_list
+
+
+def get_existing_entries(filename='league_news.txt'):
+    existing_entries = set()
+    try:
+        with open(filename, 'r', encoding='utf-8') as file:
+            for line in file:
+                if line.startswith("Link: "):
+                    url = line[len("Link: "):].strip()
+                    if url:
+                        existing_entries.add(url)
+    except FileNotFoundError:
+        pass
+    return existing_entries
+
+
+class LeagueNews:
+    def __init__(self):
+        self.news = []
+        self.base_url = game_news_list['leagueoflegends']
+        self.feed_url = f"{self.base_url}/en-us/news/tags/patch-notes/"
+
+    def get_news(self, html: str):
+        """
+        Extracts League of Legends patch note articles from HTML.
+        Returns a list of dicts: { 'title': str, 'date': str, 'link': str }
+        """
+        soup = BeautifulSoup(html, 'html.parser')
+        articles = []
+
+        for a in soup.find_all('a', attrs={'data-testid': 'articlefeaturedcard-component'}):
+            href = a.get('href', '')
+            if not href:
+                continue
+
+            title_div = a.find('div', attrs={'data-testid': 'card-title'})
+            time_tag = a.find('time')
+
+            title = title_div.get_text(strip=True) if title_div else ''
+
+            # Use ISO datetime attribute for reliable parsing
+            if time_tag and time_tag.get('datetime'):
+                try:
+                    date_obj = datetime.fromisoformat(time_tag['datetime'].replace('Z', '+00:00')).date()
+                    date = date_obj.strftime('%B %d, %Y')  # e.g. "April 28, 2026"
+                except Exception:
+                    date = time_tag.get_text(strip=True)
+            else:
+                date = ''
+
+            link = href if href.startswith('http') else f"{self.base_url}{href}"
+            articles.append({'title': title, 'date': date, 'link': link})
+
+        self.news = articles
+        return articles
+
+    def save_to_file(self, filename='league_news.txt'):
+        current_date = datetime.now().date()
+        seen_entries = get_existing_entries(filename)
+
+        with open(filename, 'a', encoding='utf-8') as f:
+            for article in self.news:
+                try:
+                    article_date = datetime.strptime(article['date'], '%B %d, %Y').date()
+                except Exception:
+                    continue
+
+                article_key = article['link']
+                if article_date == current_date and article_key not in seen_entries:
+                    title = article['title'].replace('\n', ' ')
+                    link = article['link']
+                    date = article['date'].replace('\n', ' ')
+                    f.write("LeagueNews_patchnotes:\n")
+                    f.write(f"Title: {title}\n")
+                    f.write(f"Link: {link}\n")
+                    f.write(f"Date: {date}\n\n")
+                    seen_entries.add(article_key)
+
+
+__all__ = ['LeagueNews', 'get_existing_entries']

--- a/PythonProject3/main.py
+++ b/PythonProject3/main.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from webhook import webhook
-from HackingNews import NewsFeed, clear_file, get_existing_entries
+from datetime import datetime
+
+import requests
+
 from Discord import SendToDiscord
 from GamingNews import ArcRaidersNews, get_existing_entries as get_game_existing_entries
-from datetime import datetime
+from HackingNews import NewsFeed, get_existing_entries
+from LeagueNews import LeagueNews, get_existing_entries as get_league_existing_entries
+from webhook import webhook
 
 
 def main():
@@ -35,7 +39,6 @@ def main():
     # --- Game news section ---
     game_news = ArcRaidersNews()
     # Fetch HTML from the Arc Raiders news page
-    import requests
     try:
         response = requests.get(f"{game_news.base_url}/news")
         response.raise_for_status()
@@ -50,7 +53,7 @@ def main():
     for article in game_news.news:
         try:
             article_date = datetime.strptime(article['date'], '%B %d, %Y').date()
-        except Exception:
+        except Exception as article:
             print(f"Could not parse date for article: {article}")
             continue
         article_key = article['link']
@@ -60,6 +63,33 @@ def main():
             SendToDiscord(webhook["arcRaiderNews"], article)
 
     game_news.save_to_file()
+
+    # --- League of Legends patch notes section ---
+    league_news = LeagueNews()
+    try:
+        response = requests.get(league_news.feed_url)
+        response.raise_for_status()
+        league_news.get_news(response.text)
+    except Exception as e:
+        print(f"Failed to fetch League news: {e}")
+
+    league_existing_entries = get_league_existing_entries()
+    print(f"Existing League entries: {league_existing_entries}")
+
+    for article in league_news.news:
+        try:
+            article_date = datetime.strptime(article['date'], '%B %d, %Y').date()
+        except Exception as article:
+            print(f"Could not parse date for article: {article}")
+            continue
+        article_key = article['link']
+        print(f"Checking League entry: (Title: {article['title']}, Date: {article_date}, Link: {article_key})")
+        if article_date == today and article_key not in league_existing_entries:
+            print(f"Sending League article to Discord: {article_key}")
+            SendToDiscord(webhook["leagueNews"], article)
+
+    league_news.save_to_file()
+
 
 if __name__ == "__main__":
     main()

--- a/PythonProject3/main.py
+++ b/PythonProject3/main.py
@@ -53,7 +53,7 @@ def main():
     for article in game_news.news:
         try:
             article_date = datetime.strptime(article['date'], '%B %d, %Y').date()
-        except Exception as article:
+        except Exception as e:
             print(f"Could not parse date for article: {article}")
             continue
         article_key = article['link']
@@ -79,7 +79,7 @@ def main():
     for article in league_news.news:
         try:
             article_date = datetime.strptime(article['date'], '%B %d, %Y').date()
-        except Exception as article:
+        except Exception as e:
             print(f"Could not parse date for article: {article}")
             continue
         article_key = article['link']

--- a/PythonProject3/requirements.txt
+++ b/PythonProject3/requirements.txt
@@ -1,9 +1,9 @@
-requests~=2.32.3
+requests~=2.34.1
 discord.py
 feedparser~=6.0.11
 python-dotenv~=1.2.1
 schedule~=1.2.2
-django-scheduler~=0.10.1
+django-scheduler~=0.12.0
 discord-webhook~=1.4.1
 beautifulsoup4~=4.14.3
 python-dateutil~=2.9.0.post0

--- a/PythonProject3/srcs.py
+++ b/PythonProject3/srcs.py
@@ -4,5 +4,6 @@ hacking_rss_list = {
 }
 
 game_news_list = {
-    'arcraiders': 'https://arcraiders.com'
+    'arcraiders': 'https://arcraiders.com',
+    'leagueoflegends': 'https://www.leagueoflegends.com'
 }

--- a/PythonProject3/webhook.py
+++ b/PythonProject3/webhook.py
@@ -9,9 +9,11 @@ load_dotenv()
 get_hackerNews = os.getenv("HACKERNEWS")
 get_devNews = os.getenv("DEVNEWS")
 get_arcRaiderNews = os.getenv("ARCRAIDERS")
+get_leagueNews = os.getenv("LEAGUEOFLEGENDS")
 
 webhook = {
-        'hackerNews': f"{get_hackerNews}",
-        'devNews': f"{get_devNews}",
-        'arcRaiderNews': f"{get_arcRaiderNews}"
-    }
+    'hackerNews': f"{get_hackerNews}",
+    'devNews': f"{get_devNews}",
+    'arcRaiderNews': f"{get_arcRaiderNews}",
+    'leagueNews': f"{get_leagueNews}"
+}


### PR DESCRIPTION
This pull request adds support for fetching and sending League of Legends patch notes to Discord, along with some related improvements and dependency updates. The main changes are the integration of League news into the workflow, updates to configuration and requirements, and minor code quality improvements.

**League of Legends News Integration:**

* Added a new section in `main.py` to fetch League of Legends patch notes using the new `LeagueNews` class, check for new articles, and send them to Discord if they haven't been posted yet.
* Updated `srcs.py` to include the League of Legends news source URL in the `game_news_list` dictionary.
* Modified `webhook.py` to add support for a League of Legends webhook URL in the environment variables and the `webhook` dictionary.

**Dependency and Configuration Updates:**

* Upgraded `requests` and `django-scheduler` versions in `requirements.txt` for improved compatibility and security.

**Code Quality and Refactoring:**

* Cleaned up imports in `main.py` to organize and deduplicate them.
* Improved exception handling and logging for date parsing in both Arc Raiders and League news sections.
* Removed redundant `import requests` statement from within the function in `main.py`.